### PR TITLE
Add wecombot: Python WeCom AI bot framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [lyyyuna/wechat_robot](https://github.com/lyyyuna/wechat_robot): <sup>(个人号)</sup> <sup>(CLI)</sup> 微信聊天机器人（个人账号，非订阅号）
 - [whtsky/WeRoBot](https://github.com/whtsky/WeRoBot): <sup>(公众号)</sup> <sup>(SDK)</sup> WeRoBot是一个微信机器人框架
 - [jeffkit/wechat](https://github.com/jeffkit/wechat): <sup>(公众号)</sup> <sup>(SDK)</sup> A wechat python SDK
+- [hi-xXX/wecombot](https://github.com/hi-xXX/wecombot): <sup>(企业号)</sup> <sup>(Framework)</sup> 企业微信 AI 智能客服机器人框架，内置多模型 LLM 对话、客服 API 完整封装、消息加解密与 FastAPI webhook 服务
 
 
 ## PHP


### PR DESCRIPTION
Adding [wecombot](https://github.com/hi-xXX/wecombot) to the Python section.

**What it is**: An enterprise WeChat (WeCom) AI customer service bot framework.

**Why it fills a gap**: The current Python section covers personal accounts (itchat) and official accounts (WeRoBot), but no entry for enterprise WeChat bots. wecombot targets the enterprise account category which is not represented yet.

**Highlights**:
- Python 3.8+ native
- Full kf API wrapper with AES-CBC message crypto
- FastAPI webhook service with message dedup
- Multi-model LLM support with conversation memory
- Docker one-click deploy
- MIT license
- Published on PyPI: https://pypi.org/project/wecombot/

Happy to adjust the entry format if needed.
